### PR TITLE
Add default value for gitlabhooks variable

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,5 +8,6 @@ webhook_version: '2.7.0'
 webhook_checksum: 'md5:8bb63914f4ead672ff43191e91b0249f'
 
 githubhooks: []
+gitlabhooks: []
 httphooks: []
 optional_args: ""


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Description

`gitlabhooks` variable was missing a default value (an empty array), which makes the use of this role somehow inelegant.

With this default value, one must not add a `gitlabhooks: []` when not using Gitlab webhooks.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring.
- [x] Non-breaking change (fix or feature that wouldn't cause existing functionality to change/break).
- [ ] Breaking change (fix or feature that would cause existing functionality to change/break).
